### PR TITLE
Discard fix

### DIFF
--- a/mtgengine/src/main/java/com/magicengine/Player.java
+++ b/mtgengine/src/main/java/com/magicengine/Player.java
@@ -142,6 +142,8 @@ public class Player implements Target {
 	public void discard(MagicObject card) {
 	/** Rimuove dalla mano del giocatore la carta specificata (se presente)
 	 * e la posiziona in fondo alla libreria
+	 * 
+	 * N.B.: questa regola vale solo per il mulligan !!
 	 */
 		boolean discarded = this.hand.remove(card);
 		if (discarded) {

--- a/mtgengine/src/main/java/com/magicengine/Player.java
+++ b/mtgengine/src/main/java/com/magicengine/Player.java
@@ -139,27 +139,22 @@ public class Player implements Target {
 		}	
 	}
 	
-	public void discard(MagicObject card) {
-	/** Rimuove dalla mano del giocatore la carta specificata (se presente)
-	 * e la posiziona in fondo alla libreria
+	/**
+	 * @author Nicolò Posta, Tommaso Romani, Nicolò Vescera
 	 * 
-	 * N.B.: questa regola vale solo per il mulligan !!
+	 * Rimuove dalla mano del giocatore la carta specificata (se presente)
+	 * e la posiziona in fondo alla libreria
+	 *  N.B.: questa regola viene utilizzata (per ora) solo per il mulligan !!
+	 *
+	 * @param card la carta da mettere in fondo la mazzo
 	 */
+	public void sendToBottomLibrary(MagicObject card) {
 		boolean discarded = this.hand.remove(card);
 		if (discarded) {
 			this.library.add(card);
 		}
-		
 	}
 	
-	public void discard(int card_index) {
-	/** Rimuove dalla mano del giocatore la carta corrispondente 
-	 * all'indice specificato e la posiziona in fondo alla libreria
-	 */
-		MagicObject discarded = this.hand.remove(card_index);
-		this.library.add(discarded);
-	}
-
 	public String getNickname() {
 		return nickname;
 	}

--- a/mtgengine/src/main/resources/rules/Rules.drl
+++ b/mtgengine/src/main/resources/rules/Rules.drl
@@ -704,7 +704,7 @@ dialect "mvel"
 		card = $p.hand.get(card_idx);
 		System.out.println("103.4 part 3c mulligan LONDON discard answer-> Player " + pid + "discarded " + card.getNameAsString());
 		// Scarto
-		$p.discard(card);
+		$p.sendToBottomLibrary(card);
 		$p.discarding = false;
 		retract($ca)
 		update($p)
@@ -8060,8 +8060,8 @@ rule "702.31b"
     A creature with horsemanship can't be blocked by creatures without horsemanship. 
     A creature with horsemanship can block a creature with or without horsemanship.
 
-    se il bloccate ha horsemanship può bloccare creature con o senza horsemanship
-    un attaccante con horsemanship non può essere bloccato da creature senza horsemanship
+    se il bloccate ha horsemanship puï¿½ bloccare creature con o senza horsemanship
+    un attaccante con horsemanship non puï¿½ essere bloccato da creature senza horsemanship
 */
 dialect "mvel"
 no-loop true
@@ -8085,7 +8085,7 @@ agenda-group "general"
 				for (Permanent attacker : blocker.blockedCreatures.listReference) {
 					// ... se almeno 1 attaccante ha shadow ...
 					if (attacker.checkKeywordAbility("horsemanship")){
-						// ... il blocco non è valido
+						// ... il blocco non ï¿½ valido
 						System.out.println("Blocco non valido!");
 						$g.blockValid = false;
 					}
@@ -8139,7 +8139,7 @@ agenda-group "general"
 		boolean typeArtifactCreatureFear = false;
 		// Per ogni bloccante ...
 		for (Permanent blocker : $blockers) {
-			// ... se non è di tipo artefatto o non è di colore nero...
+			// ... se non ï¿½ di tipo artefatto o non ï¿½ di colore nero...
 			//if (! blocker.getCardType().toString() == "artifact creature" or ! blocker.getColorIndicator("black")) 
 				// ... controllo le creature che blocca ...
 				for (Permanent attacker : blocker.blockedCreatures.listReference) {


### PR DESCRIPTION
Compreso il funzionamento della funzione `discard`.
Rinominata e aggiunto javadoc

## Fix

La funzione `discard` è utilizzata solo per 'scartare' le carte durante la fase di Mulligan (le carte non vengono scartate ma messe in fondo al mazzo).
Per scartare una carta si utilizza:
 
```java
player.graveyard.add(card)
```

Questa funzione è stata rinominata in `sendToBottomLibrary` ed è stato migliorato il relativo javadoc.

https://github.com/Typing-Monkeys/TeferiTheGathering/blob/1c3f773388f96b475d2a906b44c11302e698d855/mtgengine/src/main/java/com/magicengine/Player.java#L142-L156