### PR TITLE
HotFix - Sorcery

### DIFF
--- a/mtgengine/src/main/resources/rules/Rules.drl
+++ b/mtgengine/src/main/resources/rules/Rules.drl
@@ -5564,6 +5564,7 @@ when
 	$g: Game(stage == Game.GAME_STAGE, $g.getCastingSpell()!=null)
 	$spell: Spell(targetted_id==-1, $id: idPlayer, $scs: stepCastingSpell.listReference) from $g.getCastingSpell()	
 	$p: Player(id == $id)
+	eval($spell.getStepCastingSpell().getObject()!= null)
 	eval($spell.getStepCastingSpell().getObject().equals("601.2cfase1"))
 then
 	System.out.println("601.2c: si deve selezionare il target dell'aura");
@@ -5784,6 +5785,7 @@ rule "601.2f"
 		$g: Game(stage == Game.GAME_STAGE, castingSpell != null, castingSpell.getTotalCost() == null, $spell: castingSpell)
 		$act: Action($id: id, option == Game.CAST_INSTANT_SPELL || option == Game.CAST_NON_INSTANT_SPELL)
 		$p: Player(id == $id)
+		eval($spell.getStepCastingSpell().getObject() != null)
 		eval($spell.getStepCastingSpell().getObject().equals("601.2f"))
 	then
 		$spell.initializeTotalCost();
@@ -5806,6 +5808,7 @@ rule "601.2g"
 		$act: Action($id: id, option == Game.CAST_INSTANT_SPELL || option == Game.CAST_NON_INSTANT_SPELL)
 		$p: Player(id == $id)
 		not ManaAbility()
+		eval($spell.getStepCastingSpell().getObject() != null)
 		eval($spell.getStepCastingSpell().getObject().equals("601.2g"))
 	then
 		MakeChoice choice = new MakeChoice();
@@ -6000,6 +6003,7 @@ when
 	$g: Game(stage == Game.GAME_STAGE, castingSpell != null, castingSpell.sufficientMana == true, $stack: stack, $spell: castingSpell)
 	$act: Action($id: id, option == Game.CAST_INSTANT_SPELL || option == Game.CAST_NON_INSTANT_SPELL)
 	$p: Player(id == $id)
+	eval($spell.getStepCastingSpell().getObject() != null)
 	eval($spell.stepCastingSpell.getObject().equals("601.2h"))
 then
 	System.out.println("601.2h");
@@ -7877,14 +7881,12 @@ agenda-group "general"
 		$p : Player($id : id, $nickname: nickname, $deck: deck; $lib: library, library.size() > 0);
 		$c : Card() from $lib
 		$la: LinkedList() from $c.getAbilities()
-		$a : Ability(targetted_ability == false && (abilityText.contains("Target ") == true 
-			|| abilityText.contains("Targets ") == true)) from $la
+		$a : Ability(targetted_ability == false, cercaTestoNellaStringa("target") || cercaTestoNellaStringa("targets")) from $la
 	then	
+		System.out.println("La modifica che ho fatto funziona !!");
 		$a.setTargetted_ability(true);
 		$a.setManaCostSymbols();
-		System.out.println("SONO DENTRO E PRIMA DELLO SLPIT !!");
 		String[] words = $a.getAbilityText().split(" ");
-		System.out.println("SONO DENTRO E DOPO DELLO SLPIT !!");
 		
 		int i=0;
 		int j=0;

--- a/mtgengine/src/main/resources/rules/Rules.drl
+++ b/mtgengine/src/main/resources/rules/Rules.drl
@@ -7877,17 +7877,20 @@ agenda-group "general"
 		$p : Player($id : id, $nickname: nickname, $deck: deck; $lib: library, library.size() > 0);
 		$c : Card() from $lib
 		$la: LinkedList() from $c.getAbilities()
-		$a : Ability(targetted_ability == false && (abilityText.contains("target ") == true 
-			|| abilityText.contains("targets ") == true)) from $la
+		$a : Ability(targetted_ability == false && (abilityText.contains("Target ") == true 
+			|| abilityText.contains("Targets ") == true)) from $la
 	then	
 		$a.setTargetted_ability(true);
 		$a.setManaCostSymbols();
+		System.out.println("SONO DENTRO E PRIMA DELLO SLPIT !!");
 		String[] words = $a.getAbilityText().split(" ");
+		System.out.println("SONO DENTRO E DOPO DELLO SLPIT !!");
+		
 		int i=0;
 		int j=0;
 		boolean trovato=false;
 		for(i = 0; i < words.length-1; i++){
-			if(words[i].equals("target") || words[i].equals("targets")){
+			if(words[i].toLowerCase().equals("target") || words[i].toLowerCase().equals("targets")){
 				if(
 					words[i+1].equals("artifact") ||
 					words[i+1].equals("creature") ||

--- a/mtgengine/src/main/resources/rules/Rules.drl
+++ b/mtgengine/src/main/resources/rules/Rules.drl
@@ -5506,12 +5506,13 @@ when
 	eval($scs.size()==0)
 	$p: Player(id == $id)
 	$listaSottoTipi: LinkedList() from $spell.getSubtype()
-	$sottoTipo : String() from $listaSottoTipi
 then
-	if($sottoTipo == "Aura"){
-		System.out.println("AURA");
-		$scs.add("601.2cfase1");
-		$scs.add("601.2cfase2");	
+	for (String sottoTipo : $listaSottoTipi) {
+		if(sottoTipo == "Aura"){
+			System.out.println("AURA");
+			$scs.add("601.2cfase1");
+			$scs.add("601.2cfase2");	
+		}
 	}
 	////da aggiungere 
 	//$sda.add("601.2d");
@@ -5564,7 +5565,6 @@ when
 	$g: Game(stage == Game.GAME_STAGE, $g.getCastingSpell()!=null)
 	$spell: Spell(targetted_id==-1, $id: idPlayer, $scs: stepCastingSpell.listReference) from $g.getCastingSpell()	
 	$p: Player(id == $id)
-	eval($spell.getStepCastingSpell().getObject()!= null)
 	eval($spell.getStepCastingSpell().getObject().equals("601.2cfase1"))
 then
 	System.out.println("601.2c: si deve selezionare il target dell'aura");
@@ -5785,7 +5785,6 @@ rule "601.2f"
 		$g: Game(stage == Game.GAME_STAGE, castingSpell != null, castingSpell.getTotalCost() == null, $spell: castingSpell)
 		$act: Action($id: id, option == Game.CAST_INSTANT_SPELL || option == Game.CAST_NON_INSTANT_SPELL)
 		$p: Player(id == $id)
-		eval($spell.getStepCastingSpell().getObject() != null)
 		eval($spell.getStepCastingSpell().getObject().equals("601.2f"))
 	then
 		$spell.initializeTotalCost();
@@ -5808,7 +5807,6 @@ rule "601.2g"
 		$act: Action($id: id, option == Game.CAST_INSTANT_SPELL || option == Game.CAST_NON_INSTANT_SPELL)
 		$p: Player(id == $id)
 		not ManaAbility()
-		eval($spell.getStepCastingSpell().getObject() != null)
 		eval($spell.getStepCastingSpell().getObject().equals("601.2g"))
 	then
 		MakeChoice choice = new MakeChoice();
@@ -6003,7 +6001,6 @@ when
 	$g: Game(stage == Game.GAME_STAGE, castingSpell != null, castingSpell.sufficientMana == true, $stack: stack, $spell: castingSpell)
 	$act: Action($id: id, option == Game.CAST_INSTANT_SPELL || option == Game.CAST_NON_INSTANT_SPELL)
 	$p: Player(id == $id)
-	eval($spell.getStepCastingSpell().getObject() != null)
 	eval($spell.stepCastingSpell.getObject().equals("601.2h"))
 then
 	System.out.println("601.2h");
@@ -7142,7 +7139,7 @@ dialect "mvel"
 agenda-group "general"
 no-loop true 
 	when
-		$g: Game(stage == Game.GAME_STAGE, resolvingSpell != null, resolvingSpell.isPermanent == null, $id: resolvingSpell.idController)
+		$g: Game(stage == Game.GAME_STAGE, resolvingSpell != null, resolvingSpell.isPermanent == false, $id: resolvingSpell.idController)
 		$p: Player(id == $id)
 	then
 		if($g.resolvingSpell.cardType[0].contains("instant") || $g.resolvingSpell.cardType[0].contains("sorcery")) {

--- a/mtggameinterface/script/clientL.js
+++ b/mtggameinterface/script/clientL.js
@@ -231,6 +231,10 @@ window.onload = function() {
     deck1.push(2892)
     deck1.push(2892)
 
+    // Sorcery
+    deck1.push(2893)
+    deck1.push(2893)
+    deck1.push(2893)
 
 // - DECK 2 DECLARATION ----------------------------------------------------------------------------- 
     var deck2= Array(); // White/Blu


### PR DESCRIPTION
Hotfix per evitare che il cast delle Instant/Sorcery causi il crash/soft-lock del game.

## In depth 🔍 

### Sorcery - NullPointerException

La rimozione della riga seguente e le successive modifiche impedisco alla Sorcery di causare NullPointerException nelle succesive regole.
``` diff

	$p: Player(id == $id)
	$listaSottoTipi: LinkedList() from $spell.getSubtype()
-       $sottoTipo : String() from $listaSottoTipi
then
	for (String sottoTipo : $listaSottoTipi) {
		if(sottoTipo == "Aura"){
			System.out.println("AURA");
			$scs.add("601.2cfase1");
			$scs.add("601.2cfase2");	
```

La Sorcery a nostra disposizione, _Addle_, non aveva nessun sottotipo. Questo impediva alla regola `601.2c` di triggerare.

https://github.com/Typing-Monkeys/TeferiTheGathering/blob/91b7f695201c958fd3e1357d3a3a0ed0551f0497/mtgengine/src/main/resources/rules/Rules.drl#L5501-L5520

### Instant/Sorcery - SoftLock

La regola che finalizzava il cast delle Spell Instant, aveva un problema nel `when`: la condizione `resolvingSpell.isPermanent == null` era malposta in quanto bisogna controllare che sia `false` !

```diff
agenda-group "general"
no-loop true 
	when
-		$g: Game(stage == Game.GAME_STAGE, resolvingSpell != null, resolvingSpell.isPermanent == null, $id: resolvingSpell.idController)
+		$g: Game(stage == Game.GAME_STAGE, resolvingSpell != null, resolvingSpell.isPermanent == false, $id: resolvingSpell.idController)
		$p: Player(id == $id)
```

https://github.com/Typing-Monkeys/TeferiTheGathering/blob/91b7f695201c958fd3e1357d3a3a0ed0551f0497/mtgengine/src/main/resources/rules/Rules.drl#L7133-L7154